### PR TITLE
add sendgrid smtp settings to production.rb

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -37,7 +37,8 @@ Rails.application.configure do
     user_name:            ENV['GMAIL_USERNAME'],
     password:             ENV['GMAIL_PASSWORD'],
     authentication:       'plain',
-    enable_starttls_auto: true }
+    enable_starttls_auto: true
+  }
 
   # Print deprecation notices to the Rails logger.
   config.active_support.deprecation = :log

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -1,4 +1,13 @@
 Rails.application.configure do
+  config.action_mailer.delivery_method = :smtp
+  ActionMailer::Base.smtp_settings = {
+    :user_name => ENV['SENDGRID_USERNAME'],
+    :password => ENV['SENDGRID_PASSWORD'],
+    :address => 'smtp.sendgrid.net',
+    :port => 587,
+    :authentication => :plain,
+    :enable_starttls_auto => true
+  }
   # Settings specified here will take precedence over those in config/application.rb.
 
   # Code is not reloaded between requests.


### PR DESCRIPTION
Changes Made:
+ add sendgrid smtp settings to production.rb

Related Issue(s):

Reviewers:
